### PR TITLE
Fix "Method eventDispatcher was used as a property; add () to call it" error

### DIFF
--- a/ios/RNSwiftSocketIO/Socket.swift
+++ b/ios/RNSwiftSocketIO/Socket.swift
@@ -64,7 +64,7 @@ class SocketIO: NSObject {
   @objc func addHandlers(handlers: NSDictionary) -> Void {
     for handler in handlers {
       self.socket.on(handler.key as! String) { data, ack in
-        self.bridge.eventDispatcher.sendDeviceEventWithName(
+        self.bridge.eventDispatcher().sendDeviceEventWithName(
           "socketEvent", body: handler.key as! String)
       }
     }
@@ -84,10 +84,10 @@ class SocketIO: NSObject {
 
   private func onAnyEventHandler (sock: SocketAnyEvent) -> Void {
     if let items = sock.items {
-      self.bridge.eventDispatcher.sendDeviceEventWithName("socketEvent",
+      self.bridge.eventDispatcher().sendDeviceEventWithName("socketEvent",
         body: ["name": sock.event, "items": items])
     } else {
-      self.bridge.eventDispatcher.sendDeviceEventWithName("socketEvent",
+      self.bridge.eventDispatcher().sendDeviceEventWithName("socketEvent",
         body: ["name": sock.event])
     }
   }


### PR DESCRIPTION
React Native Version: 0.26.3

Hello,

This patch is to fix an issue where upon build you'll receive the following errors:

```
Method eventDispatcher was used as a property; add () to call it
```

Build Screen:
![screen shot 2016-06-06 at 9 39 13 am](https://cloud.githubusercontent.com/assets/178271/15809401/6ce6c92c-2bcb-11e6-8d8e-374a50849fcf.png)
