### PR TITLE
fix compile for SocketIoReadableNativeMap

### DIFF
--- a/android/src/main/java/com/gcrabtree/rctsocketio/SocketIoReadableNativeMap.java
+++ b/android/src/main/java/com/gcrabtree/rctsocketio/SocketIoReadableNativeMap.java
@@ -2,6 +2,7 @@ package com.gcrabtree.rctsocketio;
 
 import android.util.Log;
 
+import com.facebook.jni.HybridData;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableNativeMap;
 
@@ -15,6 +16,11 @@ import io.socket.client.IO;
 
 public class SocketIoReadableNativeMap extends ReadableNativeMap {
     private static final String TAG = "SIOReadableNativeMap";
+
+    protected SocketIoReadableNativeMap(HybridData hybridData) {
+      super(hybridData);
+    }
+
     /**
      * Note: This will only be necessary until RN version 0.26 goes live
      * It will be deprecated from the project, as this is just included in that version of RN.


### PR DESCRIPTION
closes gcrabtree/react-native-socketio#8

corrects the following error:
> constructor ReadableNativeMap in class ReadableNativeMap cannot be applied to given types

making this change manually in my local `node_modules/react-native-socketio` directory corrected the issue.


